### PR TITLE
Use theme location as the cache key

### DIFF
--- a/menu-cache.php
+++ b/menu-cache.php
@@ -153,7 +153,7 @@ class Menu_Cache {
 	 */
 	public function set_cached_menu( $nav_menu, $args ) {
 
-		$transient = $this->get_transient( $args );
+		$transient = $this->get_transient( $args->theme_location );
 		set_transient( $transient, $nav_menu, $this->cache_time );
 
 		return $nav_menu;
@@ -168,7 +168,7 @@ class Menu_Cache {
 	 */
 	public function get_cached_menu( $dep = null, $args ) {
 
-		$transient = $this->get_transient( $args );
+		$transient = $this->get_transient( $args->theme_location );
 
 		// Return the cached menu if possible
 		if ( false === ( $menu = get_transient( $transient ) ) ) {

--- a/menu-cache.php
+++ b/menu-cache.php
@@ -4,7 +4,7 @@ Plugin Name: Menu Cache
 Plugin URI: https://geek.hellyer.kiwi/plugins/menu-cache/
 Description: Caches WordPress navigation menus
 Author: Ryan Hellyer
-Version: 1.0.1
+Version: 1.0.2
 Author URI: https://geek.hellyer.kiwi/
 Text Domain: menu-cache
 


### PR DESCRIPTION
I ran into an issue with this plugin together with Polylang - Polylang would dynamically insert additional data (language switcher) into the `$args` array that would make it differ between the `pre_wp_nav_menu` and `wp_nav_menu` hooks.

Looking into it, I found a very simple solution would be to base the menu cache key off the theme location instead of the entire `$args` array. The menu location is fixed and only one menu can be assigned per location, so this shouldn't affect any existing functionality. It will however improve the compatibility with plugins that insert dynamic data into `wp_nav_menu`.
