### PR TITLE
Save snapshot of original menu arguments and use it in transient name

### DIFF
--- a/menu-cache.php
+++ b/menu-cache.php
@@ -64,7 +64,20 @@ class Menu_Cache {
 	 * @access   protected
 	 */
 	protected function get_transient( $args ) {
-		$transient = 'nav-' . md5( get_option( self::CACHE_KEY ) . $_SERVER['REQUEST_URI'] . var_export( $args, true ) );
+		// Check if unique hash for the menu was set
+		if ( ! isset( $args->menu_cache_hash ) ) {
+			/**
+			 * Filters the hash of a navigation menu.
+			 *
+			 * @param string   $hash MD5 hash of parsable string representation of wp_nav_menu() arguments.
+			 * @param stdClass $args An object containing wp_nav_menu() arguments.
+			 */
+			$hash = apply_filters( 'menu_cache_hash', md5( var_export( $args, true ) ), $args );
+
+			$args->menu_cache_hash = (string) $hash;
+		}
+
+		$transient = 'nav-' . md5( get_option( self::CACHE_KEY ) . $_SERVER['REQUEST_URI'] . $args->menu_cache_hash );
 		return $transient;
 	}
 


### PR DESCRIPTION
If `menu` argument is not set for a menu, `wp_nav_menu()` sets one. This means that there is a difference between original arguments (that we use when checking for cache, on `pre_wp_nav_menu`) and those we use when we want to set cache (on `wp_nav_menu`). Because of this, plugin doesn't work for many cases and it can create opposite effect.

In #1, another example was shown where menu arguments can be modified in a similar way.

This change adds a hash of menu arguments as a property of that object and uses it when generating menu cache key.