### PR TITLE
Make current page URI filterable

### DIFF
--- a/menu-cache.php
+++ b/menu-cache.php
@@ -80,13 +80,10 @@ class Menu_Cache {
 		/**
 		 * Filters the URI of a current page.
 		 *
-		 * @param string $uri The URI which was given in order 
-to access current page.
-		 * @param stdClass $args An object containing 
-wp_nav_menu() arguments.
+		 * @param string $uri The URI which was given in order to access current page.
+		 * @param stdClass $args An object containing wp_nav_menu() arguments.
 		 */
-		$request_uri = apply_filters( 'menu_cache_request_uri', 
-$_SERVER['REQUEST_URI'], $args );
+		$request_uri = apply_filters( 'menu_cache_request_uri', $_SERVER['REQUEST_URI'], $args );
 
 		$transient = 'nav-' . md5( $this->get_cache_version() . $request_uri . $args->menu_cache_hash );
 		return $transient;

--- a/menu-cache.php
+++ b/menu-cache.php
@@ -64,7 +64,15 @@ class Menu_Cache {
 	 * @access   protected
 	 */
 	protected function get_transient( $args ) {
-		$transient = 'nav-' . md5( get_option( self::CACHE_KEY ) . $_SERVER['REQUEST_URI'] . var_export( $args, true ) );
+		/**
+		 * Filters the URI of a current page.
+		 *
+		 * @param string   $uri  The URI which was given in order to access current page.
+		 * @param stdClass $args An object containing wp_nav_menu() arguments.
+		 */
+		$request_uri = apply_filters( 'menu_cache_request_uri', $_SERVER['REQUEST_URI'], $args );
+
+		$transient = 'nav-' . md5( get_option( self::CACHE_KEY ) . $request_uri . var_export( $args, true ) );
 		return $transient;
 	}
 


### PR DESCRIPTION
While some themes use `current-menu-item` class and request current behaviour of this plugin, where menu is cached separately for each unique page, some themes don't use this class and one menu output can be used on all pages.

This change introduces filter so you can easily modify request URI used in menu cache key. For example, if you want to use one output for all pages, you can add `add_filter( 'menu_cache_request_uri', '__return_empty_string' );` which improves caching by removing unnecessary database requests and fields.