### PR TITLE
Set version timestamp if it doesn't exist

### DIFF
--- a/menu-cache.php
+++ b/menu-cache.php
@@ -64,7 +64,7 @@ class Menu_Cache {
 	 * @access   protected
 	 */
 	protected function get_transient( $args ) {
-		$transient = 'nav-' . md5( get_option( self::CACHE_KEY ) . $_SERVER['REQUEST_URI'] . var_export( $args, true ) );
+		$transient = 'nav-' . md5( $this->get_cache_version() . $_SERVER['REQUEST_URI'] . var_export( $args, true ) );
 		return $transient;
 	}
 
@@ -142,6 +142,25 @@ class Menu_Cache {
 	 */
 	public function refresh_cache() {
 		update_option( self::CACHE_KEY, time() );
+	}
+
+	/**
+	 * Get current version of cache.
+	 *
+	 * @return string $version Cache version
+	 */
+	public function get_cache_version() {
+		$version = get_option( self::CACHE_KEY );
+
+		// If no version was set, set new one
+		if ( ! $version ) {
+			$this->refresh_cache();
+
+			// Get new version
+			$version = get_option( self::CACHE_KEY );
+		}
+
+		return $version;
 	}
 
 	/**


### PR DESCRIPTION
Until menu is edited or cache is manually purged, database option key doesn't exist but it's always queried for. This creates unnecessary empty database request. When option exists, it's loaded with `wp_load_alloptions()` so there is no need for additional query.

This change always adds database option.