### PR TITLE
Make plugin class instance available

### DIFF
--- a/menu-cache.php
+++ b/menu-cache.php
@@ -180,4 +180,4 @@ class Menu_Cache {
 	}
 
 }
-new Menu_Cache();
+$GLOBALS['menu_cache'] = new Menu_Cache();


### PR DESCRIPTION
Plugin's code is wrapped inside class which is initiated without making that instance available and that is [bad practice](http://blog.milandinic.com/2016/09/23/make-wordpress-php-class-instances-available-to-developers/).

This change adds instance as a global variable.